### PR TITLE
Fixed missing XorStrs.

### DIFF
--- a/version/Memory.h
+++ b/version/Memory.h
@@ -4,6 +4,7 @@
 #include "string"
 #include <Psapi.h>
 #include <vector>
+#include "xorstr.hpp"
 
 namespace Memory
 {
@@ -11,7 +12,7 @@ namespace Memory
 		// Get the base address of the module
 		HMODULE moduleHandle = GetModuleHandleA(moduleName);
 		if (!moduleHandle) {
-			std::cerr << "Failed to get module handle." << std::endl;
+			std::cerr << _XOR_("Failed to get module handle.") << std::endl;
 			return 0;
 		}
 
@@ -47,7 +48,7 @@ namespace Memory
 			}
 		}
 
-		std::cerr << "Pattern not found." << std::endl;
+		std::cerr << _XOR_("Pattern not found.") << std::endl;
 		return 0;
 	}
 

--- a/version/dllmain.cpp
+++ b/version/dllmain.cpp
@@ -566,7 +566,7 @@ DWORD WINAPI Payload(LPVOID lpParam)
                     };
 
                     uintptr_t ShowAllMapIconsAddr = Memory::FindPattern(_XOR_("game.dll"), _XOR_("41 0F B6 44 97 23"));
-                    uintptr_t aob_CheckIfAlienHivesAreObstructed = Memory::FindPattern(_XOR_("game.dll"), "41 80 BE 3C BA 07 00 00");
+                    uintptr_t aob_CheckIfAlienHivesAreObstructed = Memory::FindPattern(_XOR_("game.dll"), _XOR_("41 80 BE 3C BA 07 00 00"));
                     uintptr_t aob_CheckIfMinorInterestBlipIsDiscovered = Memory::FindPattern(_XOR_("game.dll"), _XOR_("0F 85 ?? ?? ?? ?? 48 8B 44 24 ?? 80 78 29 00"));
                     uintptr_t aob_GetMinorInterestBlipIcon = Memory::FindPattern(_XOR_("game.dll"), _XOR_("0F 84 ?? ?? ?? ?? 48 8B 4C 24 ?? F3 41 0F 10 4F"));
                     uintptr_t aob_CheckMissionBlip = Memory::FindPattern(_XOR_("game.dll"), _XOR_("0F 85 59 02 00 00 49 8D"));

--- a/version/version.h
+++ b/version/version.h
@@ -2,6 +2,7 @@
 #pragma once
 #include <cstdint>
 #include <Windows.h>
+#include "xorstr.hpp"
 
 namespace dllforward
 {
@@ -161,13 +162,12 @@ namespace dllforward
 
 #pragma optimize("", on)
 
-		constexpr char proxiedDll[]{ "C:/Windows/System32/version.dll" };
 		constexpr Export exports[]{ { __EXPORT_DUMMY1, "GetFileVersionInfoA", 1, 0x1ee0 }, { __EXPORT_DUMMY2, "GetFileVersionInfoByHandle", 2, 0x23e0 }, { __EXPORT_DUMMY3, "GetFileVersionInfoExA", 3, 0x1f00 }, { __EXPORT_DUMMY4, "GetFileVersionInfoExW", 4, 0x1070 }, { __EXPORT_DUMMY5, "GetFileVersionInfoSizeA", 5, 0x1010 }, { __EXPORT_DUMMY6, "GetFileVersionInfoSizeExA", 6, 0x1f20 }, { __EXPORT_DUMMY7, "GetFileVersionInfoSizeExW", 7, 0x1090 }, { __EXPORT_DUMMY8, "GetFileVersionInfoSizeW", 8, 0x10b0 }, { __EXPORT_DUMMY9, "GetFileVersionInfoW", 9, 0x10d0 }, { __EXPORT_DUMMY10, "VerFindFileA", 10, 0x1f40 }, { __EXPORT_DUMMY11, "VerFindFileW", 11, 0x25a0 }, { __EXPORT_DUMMY12, "VerInstallFileA", 12, 0x1f60 }, { __EXPORT_DUMMY13, "VerInstallFileW", 13, 0x3390 }, { __EXPORT_DUMMY14, "VerLanguageNameA", 14, 0x506c }, { __EXPORT_DUMMY15, "VerLanguageNameW", 15, 0x5097 }, { __EXPORT_DUMMY16, "VerQueryValueA", 16, 0x1030 }, { __EXPORT_DUMMY17, "VerQueryValueW", 17, 0x1050 } };
 	}
 
 	static HMODULE setup()
 	{
-		HMODULE hProxiedDLL{ LoadLibraryA(internal::proxiedDll) };
+		HMODULE hProxiedDLL = LoadLibraryA(_XOR_("C:/Windows/System32/version.dll"));
 
 		if (!hProxiedDLL)
 			return NULL;

--- a/version/xorstr.hpp
+++ b/version/xorstr.hpp
@@ -26,6 +26,7 @@
 */
 
 #include <Windows.h>
+#include <stdlib.h>
 
 #define XORSTR_INLINE	__forceinline
 #define XORSTR_NOINLINE __declspec( noinline )


### PR DESCRIPTION
With this change there are now no anomalous strings in RDATA that don't already belong to the stock version.dll. If they try to statically detect our XorStr, it should be as simple as adding a salt to our implementation and it should shift the bytes.