### PR TITLE
Fixed MSBuild warnings caused by using outdated actions

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v2
 
     - name: Restore NuGet packages
       working-directory: ${{env.GITHUB_WORKSPACE}}


### PR DESCRIPTION
![image](https://github.com/emoisback/Helldivers-2-Internal-Hack-Dll-Proxy-PoC/assets/49344045/07af2f49-01ae-45cd-9ff3-679b0652fcea)
